### PR TITLE
Pass the Play Application to the applicationModule function.

### DIFF
--- a/src/main/scala/scaldi/play/ScaldiSupport.scala
+++ b/src/main/scala/scaldi/play/ScaldiSupport.scala
@@ -42,7 +42,7 @@ trait ScaldiSupport extends GlobalSettings with Injectable {
   /**
    * @return the application module to use
    */
-  def applicationModule: Injector
+  def applicationModule(app: Application): Injector
 
   /**
    * The current injector when the application is running.
@@ -54,7 +54,7 @@ trait ScaldiSupport extends GlobalSettings with Injectable {
   }
 
   private def createApplicationInjector(currentApplication: Application): Injector with LifecycleManager =
-    applicationModule ::
+    applicationModule(currentApplication) ::
       new PlayConfigurationInjector(currentApplication) ::
       new PlayAppModule(currentApplication)
 


### PR DESCRIPTION
In some module I need to access the Play Configuration to get some
configured value. To achieve this the applicationModule now gets
passed the Play Application instance. I prefer to provide the Application
explicitely over accessing it via Play.current because it makes clear
that the Application is already available.
I chose to provide the Play Application instead of just the Configuration
because then Plugins are available as well.

The downside of this change is that it's not backward compatible.
