### PR TITLE
Inspect Interfaces BindingKey Qualifiers for Qualifier Annotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.4.0-M2" % "provided",
+  /* Included specifically to address the issue reported at https://github.com/scaldi/scaldi-play/issues/10. */
+  "com.typesafe.play" %% "play-cache" % "2.4.0-M2" % "provided",
   "org.scaldi" %% "scaldi" % "0.5.3",
 
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",

--- a/src/main/scala/scaldi/play/ScaldiApplicationLoader.scala
+++ b/src/main/scala/scaldi/play/ScaldiApplicationLoader.scala
@@ -127,7 +127,8 @@ object ScaldiApplicationLoader extends Injectable {
 
     val qualifier = key.qualifier map {
       case QualifierInstance(a: Named) => StringIdentifier(a.value())
-      case QualifierInstance(a) if a.getClass.getAnnotation(classOf[Qualifier]) != null =>
+      /* Second pattern condition addresses https://github.com/scaldi/scaldi-play/issues/10. */
+      case QualifierInstance(a) if a.getClass.getAnnotation(classOf[Qualifier]) != null || a.getClass.getInterfaces.map(_.getAnnotation(classOf[Qualifier])).filterNot(null ==).nonEmpty =>
         AnnotationIdentifier(mirror.classSymbol(a.getClass).toType)
       case QualifierClass(clazz) => AnnotationIdentifier(mirror.classSymbol(clazz).toType)
     }

--- a/src/main/scala/scaldi/play/ScaldiApplicationLoader.scala
+++ b/src/main/scala/scaldi/play/ScaldiApplicationLoader.scala
@@ -127,9 +127,13 @@ object ScaldiApplicationLoader extends Injectable {
 
     val qualifier = key.qualifier map {
       case QualifierInstance(a: Named) => StringIdentifier(a.value())
+      case QualifierInstance(a) if a.getClass.getAnnotation(classOf[Qualifier]) != null =>
+      AnnotationIdentifier(mirror.classSymbol(a.getClass).toType)
       /* Second pattern condition addresses https://github.com/scaldi/scaldi-play/issues/10. */
-      case QualifierInstance(a) if a.getClass.getAnnotation(classOf[Qualifier]) != null || a.getClass.getInterfaces.map(_.getAnnotation(classOf[Qualifier])).filterNot(null ==).nonEmpty =>
-        AnnotationIdentifier(mirror.classSymbol(a.getClass).toType)
+      case QualifierInstance(a) if a.getClass.getInterfaces.map(_.getAnnotation(classOf[Qualifier])).filterNot(null ==).nonEmpty =>
+        /* FIXME: There's probably a more efficient method. */
+        val qualifierInterface = a.getClass.getInterfaces.find(null != _.getAnnotation(classOf[Qualifier]))
+        AnnotationIdentifier(mirror.classSymbol(qualifierInterface.getClass).toType)
       case QualifierClass(clazz) => AnnotationIdentifier(mirror.classSymbol(clazz).toType)
     }
 


### PR DESCRIPTION
Addresses issue #10. Also includes a dependency on `play-cache`, which trips this issue in unit tests.