### PR TITLE
removed the guice dependency in scaldi-play

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ val slickVersion = "3.0.2"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % playVersion % "provided",
-  "com.typesafe.play" %% "play-guice" % playVersion % "provided",
   "org.scaldi" %% "scaldi-jsr330" % "0.5.9",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",
   "com.typesafe.play" %% "play-test" % playVersion % "test",

--- a/src/main/scala/scaldi/play/ScaldiBuilder.scala
+++ b/src/main/scala/scaldi/play/ScaldiBuilder.scala
@@ -2,7 +2,6 @@ package scaldi.play
 
 import java.io.File
 
-import com.google.inject.CreationException
 import play.api._
 import play.api.inject.{Binding => PlayBinding, Injector => PlayInjector, Module => PlayModule, _}
 
@@ -97,9 +96,10 @@ abstract class ScaldiBuilder[Self] protected (
 
       injector -> Injectable.inject[PlayInjector]
     } catch {
-      case e: CreationException => e.getCause match {
-        case p: PlayException => throw p
-        case _ => throw e
+      case p: PlayException => throw p
+      case t: Throwable => t.getCause match {
+        case pe: PlayException => throw pe
+        case _ => throw t
       }
     }
   }

--- a/src/main/scala/scaldi/play/ScaldiBuilder.scala
+++ b/src/main/scala/scaldi/play/ScaldiBuilder.scala
@@ -96,11 +96,8 @@ abstract class ScaldiBuilder[Self] protected (
 
       injector -> Injectable.inject[PlayInjector]
     } catch {
-      case p: PlayException => throw p
-      case t: Throwable => t.getCause match {
-        case pe: PlayException => throw pe
-        case _ => throw t
-      }
+      // unwrap play exceptions that are causes of com.google.inject.CreationException without importing guice
+      case t: Throwable if t.getCause.isInstanceOf[PlayException] => throw t.getCause
     }
   }
 


### PR DESCRIPTION
#37 
removed the dependency on play-guice in build.sbt
removed the reference to com.google.inject.CreationException in ScaldiBuilder.scala and made the catch block more generic